### PR TITLE
Correctie van id NHN

### DIFF
--- a/xml/NeTEx_DOVA_networks.xml
+++ b/xml/NeTEx_DOVA_networks.xml
@@ -334,7 +334,7 @@
 							<GroupOfLinesType>administrative</GroupOfLinesType>
 							<AuthorityRef ref="DOVA:Authority:PNH" version="any"/>
 						</Network>
-						<TransportAdministrativeZone id="DOVA:TransportAdministrativeZone:HNH" version="any">
+						<TransportAdministrativeZone id="DOVA:TransportAdministrativeZone:NHN" version="any">
 							<Name>Noord-Holland Noord</Name>
 							<ShortName>NHN</ShortName>
 						</TransportAdministrativeZone>


### PR DESCRIPTION
De id DOVA:TransportAdministrativeZone:HNH zou DOVA:TransportAdministrativeZone:NHN conform de opbouw van alle andere id's.